### PR TITLE
integrate consul support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ RUN \
   apk update --quiet --no-cache && \
   apk upgrade --quiet --no-cache && \
   apk add --quiet --no-cache \
+    curl \
+    jq \
+    util-linux \
     mariadb \
     mariadb-client \
     pwgen && \

--- a/docker-compose_example.yml
+++ b/docker-compose_example.yml
@@ -8,23 +8,32 @@ services:
     container_name: consul-master
     hostname: consul-master
     ports:
+      - 8300:8300
+      - 8301:8301
+      - 8301:8301/udp
+      - 8302:8302
+      - 8302:8302/udp
       - 8400:8400
       - 8500:8500
+      - 8600:8600
+      - 8600:8600/udp
       - 53:53
+    environment:
+      - CONSUL_UI_BETA=true
     command: 'agent -data-dir /data -server -bootstrap-expect 1 -ui -client=0.0.0.0'
 
-#  registrator:
-#    image: gliderlabs/registrator:latest
-#    restart: always
-#    container_name: registrator
-#    hostname: registrator
-#    volumes:
-#      - /var/run/docker.sock:/tmp/docker.sock
-#    command: consul://consul-master:8500
-#    links:
-#      - consul-master
-##    network_mode: host
-#
+  registrator:
+    image: gliderlabs/registrator:latest
+    restart: always
+    container_name: registrator
+    hostname: registrator
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock
+    command: consul://consul-master:8500
+    links:
+      - consul-master
+#    network_mode: host
+
 
   database:
     #image: bodsch/docker-mysql:10.1.28-r1
@@ -38,6 +47,7 @@ services:
     environment:
       - MYSQL_SYSTEM_USER=root
       - MYSQL_ROOT_PASS=vYUQ14SGVrJRi69PsujC
+      - CONFIG_BACKEND=consul
       - CONSUL=consul-master
     links:
       - consul-master

--- a/docker-compose_example.yml
+++ b/docker-compose_example.yml
@@ -1,0 +1,43 @@
+---
+version: '3.3'
+
+services:
+
+  consul-master:
+    image: bodsch/docker-consul
+    container_name: consul-master
+    hostname: consul-master
+    ports:
+      - 8400:8400
+      - 8500:8500
+      - 53:53
+    command: 'agent -data-dir /data -server -bootstrap-expect 1 -ui -client=0.0.0.0'
+
+#  registrator:
+#    image: gliderlabs/registrator:latest
+#    restart: always
+#    container_name: registrator
+#    hostname: registrator
+#    volumes:
+#      - /var/run/docker.sock:/tmp/docker.sock
+#    command: consul://consul-master:8500
+#    links:
+#      - consul-master
+##    network_mode: host
+#
+
+  database:
+    #image: bodsch/docker-mysql:10.1.28-r1
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - BUILD_DATE=${BUILD_DATE}
+    container_name: database
+    hostname: database
+    environment:
+      - MYSQL_SYSTEM_USER=root
+      - MYSQL_ROOT_PASS=vYUQ14SGVrJRi69PsujC
+      - CONSUL=consul-master
+    links:
+      - consul-master

--- a/rootfs/init/consul.sh
+++ b/rootfs/init/consul.sh
@@ -1,54 +1,100 @@
 #!/bin/sh
 
-set -x
-
-if [[ -z "${CONSUL}" ]]
+if [[ -z "${CONSUL}" ]] || [[ -z "${CONFIG_BACKEND}"  ]]
 then
   return
 fi
 
-register()  {
+log_info "use '${CONFIG_BACKEND}' as configuration backend"
 
-#  data=$(curl \
-#    --request PUT \
-#    ${CONSUL}:8500/v1/agent/service/register \
-#    --data "{
-#      \"ID\": \"${HOSTNAME}\",
-#      \"Name\":\"${HOSTNAME}\",
-#      \"Port\": 3306,
-#      \"tags\": [\"database\"]
-#    }")
-#
-#  echo "${data}"
+wait_for_consul() {
+
+  RETRY=50
+  local http_response_code=0
+
+  until [[ 200 -ne $http_response_code ]] && [[ ${RETRY} -le 0 ]]
+  do
+    http_response_code=$(curl \
+      -w %{response_code} \
+      --silent \
+      --output /dev/null \
+      ${CONSUL}:8500/v1/health/service/consul)
+
+    [[ 200 -eq $http_response_code ]] && break
+
+    sleep 5s
+
+    RETRY=$(expr ${RETRY} - 1)
+  done
+
+  if [[ ${RETRY} -le 0 ]]
+  then
+    log_error "could not connect to the consul master instance '${CONSUL}'"
+    exit 1
+  fi
+}
+
+register_node()  {
+
+  local address=$(hostname -i)
+
+  data=$(curl \
+    --silent \
+    --request PUT \
+    ${CONSUL}:8500/v1/agent/service/register \
+    --data '{
+      "ID": "'${HOSTNAME}'",
+      "Name": "'${HOSTNAME}'",
+      "Port": 3306,
+      "Address": "'${address}'",
+      "tags": ["database"]
+    }')
+
+  echo "${data}"
+}
+
+set_consul_var() {
+
+  local consul_key=${1}
+  local consul_var=${2}
 
   data=$(curl \
     --request PUT \
     --silent \
-    ${CONSUL}:8500/v1/kv/database \
-    --data "{
-      \"system_user\": \"${MYSQL_SYSTEM_USER}\",
-      \"root_password\": \"${MYSQL_ROOT_PASS}\"
-    }")
+    ${CONSUL}:8500/v1/kv/${consul_key} \
+    --data ${consul_var})
+#  curl \
+#    --silent \
+#    ${CONSUL}:8500/v1/kv/${consul_key}
+}
 
-  echo "${data}"
+get_consult_var() {
+
+  local consul_key=${1}
 
   data=$(curl \
     --silent \
-    ${CONSUL}:8500/v1/kv/database)
+    ${CONSUL}:8500/v1/kv/${consul_key})
 
-  echo "---------------------------------"
-  echo -e ${data}
-  echo "---------------------------------"
+  if [[ ! -z "${data}" ]]
+  then
+    value=$(echo -e ${data} | jq --raw-output .[].Value 2> /dev/null)
 
-  which base64
-#  data=$(curl \
-#    --silent \
-#    ${CONSUL}:8500/v1/kv/database/root_password)
-#
-#  echo "${data}"
-
+    if [[ ! -z "${value}" ]]
+    then
+      echo ${value} | base64 -d
+    else
+      echo ""
+      #echo "${decoded}"
+    fi
+  fi
 }
 
-register
-
-set +x
+if [[ "${CONFIG_BACKEND}" = "consul" ]]
+then
+  wait_for_consul
+  register_node
+  set_consul_var  'database/root/user' ${MYSQL_SYSTEM_USER}
+  set_consul_var  'database/root/password' ${MYSQL_ROOT_PASS}
+  set_consul_var  'database/url' ${HOSTNAME}
+fi

--- a/rootfs/init/consul.sh
+++ b/rootfs/init/consul.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+set -x
+
+if [[ -z "${CONSUL}" ]]
+then
+  return
+fi
+
+register()  {
+
+#  data=$(curl \
+#    --request PUT \
+#    ${CONSUL}:8500/v1/agent/service/register \
+#    --data "{
+#      \"ID\": \"${HOSTNAME}\",
+#      \"Name\":\"${HOSTNAME}\",
+#      \"Port\": 3306,
+#      \"tags\": [\"database\"]
+#    }")
+#
+#  echo "${data}"
+
+  data=$(curl \
+    --request PUT \
+    --silent \
+    ${CONSUL}:8500/v1/kv/database \
+    --data "{
+      \"system_user\": \"${MYSQL_SYSTEM_USER}\",
+      \"root_password\": \"${MYSQL_ROOT_PASS}\"
+    }")
+
+  echo "${data}"
+
+  data=$(curl \
+    --silent \
+    ${CONSUL}:8500/v1/kv/database)
+
+  echo "---------------------------------"
+  echo -e ${data}
+  echo "---------------------------------"
+
+  which base64
+#  data=$(curl \
+#    --silent \
+#    ${CONSUL}:8500/v1/kv/database/root_password)
+#
+#  echo "${data}"
+
+}
+
+register
+
+set +x

--- a/rootfs/init/run.sh
+++ b/rootfs/init/run.sh
@@ -113,6 +113,8 @@ run() {
 
     bootstrap_database
 
+    . /init/consul.sh
+
     log_info "start instance"
     /usr/bin/mysqld \
       --user=${MYSQL_SYSTEM_USER} \


### PR DESCRIPTION
when environment variables `CONFIG_BACKEND=consul` and `CONSUL` are defined, the  conatiner will store variables into a consul cluster.
this is a preparment for an config-less container cluser